### PR TITLE
Support Blender 2.81

### DIFF
--- a/gridmarkets_blender_addon/api_constants.py
+++ b/gridmarkets_blender_addon/api_constants.py
@@ -23,8 +23,9 @@ class PRODUCTS:
     VRAY = "vray"
 
 class BLENDER_VERSIONS:
+    V_2_81A = "2.81a"
     V_2_80 = "2.80"
-    V_2_79 = "2.79"
+    V_2_79B = "2.79b"
 
 class BLENDER_ENGINES:
     CYCLES = "CYCLES"

--- a/gridmarkets_blender_addon/blender_plugin/remote_project_container/layouts/draw_remote_project_summary.py
+++ b/gridmarkets_blender_addon/blender_plugin/remote_project_container/layouts/draw_remote_project_summary.py
@@ -2,6 +2,7 @@ def draw_remote_project_summary(layout, project_name, project_type,
                                 blender_version, project_file, blender_280_engine, blender_279_engine,
                                 vray_version, remap_file):
 
+    import bpy
     from gridmarkets_blender_addon import api_constants
 
     box = layout.box()
@@ -24,10 +25,10 @@ def draw_remote_project_summary(layout, project_name, project_type,
         col1.label(text="Project File:")
         col2.label(text=project_name + '/' + project_file)
 
-        if blender_version == api_constants.BLENDER_VERSIONS.V_2_80:
+        if bpy.app.version[1] >= 80:
             col1.label(text="Engine")
             col2.label(text=blender_280_engine)
-        elif blender_version == api_constants.BLENDER_VERSIONS.V_2_79:
+        elif bpy.app.version[1] <= 79:
             col1.label(text="Engine")
             col2.label(text=blender_279_engine)
 

--- a/gridmarkets_blender_addon/blender_plugin/remote_project_container/operators/add_remote_project.py
+++ b/gridmarkets_blender_addon/blender_plugin/remote_project_container/operators/add_remote_project.py
@@ -83,7 +83,7 @@ class GRIDMARKETS_OT_add_remote_project(bpy.types.Operator):
 
         if self.project_type == api_constants.PRODUCTS.BLENDER:
             main_file = pathlib.Path(self.project_file + constants.BLEND_FILE_EXTENSION)
-            remote_project = RemoteBlenderProject(dir, main_file )
+            remote_project = RemoteBlenderProject(dir, main_file)
 
         elif self.project_type == api_constants.PRODUCTS.VRAY:
             main_file = pathlib.Path(self.project_file + constants.VRAY_SCENE_FILE_EXTENSION)
@@ -114,9 +114,9 @@ class GRIDMARKETS_OT_add_remote_project(bpy.types.Operator):
             layout.prop(self, "project_file")
             project_file = self.project_file + constants.BLEND_FILE_EXTENSION
 
-            if self.blender_version == api_constants.BLENDER_VERSIONS.V_2_80:
+            if self.blender_version == api_constants.BLENDER_VERSIONS.V_2_80 or self.blender_version == api_constants.BLENDER_VERSIONS.V_2_81A:
                 layout.prop(self, "blender_280_engine")
-            elif self.blender_version == api_constants.BLENDER_VERSIONS.V_2_79:
+            elif self.blender_version == api_constants.BLENDER_VERSIONS.V_2_79B:
                 layout.prop(self, "blender_279_engine")
 
         elif self.project_type == api_constants.PRODUCTS.VRAY:

--- a/gridmarkets_blender_addon/blender_plugin/remote_project_container/operators/upload_file_as_project.py
+++ b/gridmarkets_blender_addon/blender_plugin/remote_project_container/operators/upload_file_as_project.py
@@ -200,9 +200,9 @@ class GRIDMARKETS_OT_upload_file_as_project(bpy.types.Operator, ImportHelper):
         if self.project_type == api_constants.PRODUCTS.BLENDER:
             layout.prop(self, "blender_version")
 
-            if self.blender_version == api_constants.BLENDER_VERSIONS.V_2_80:
+            if self.blender_version == api_constants.BLENDER_VERSIONS.V_2_80 or self.blender_version == api_constants.BLENDER_VERSIONS.V_2_81A:
                 layout.prop(self, "blender_280_engine")
-            elif self.blender_version == api_constants.BLENDER_VERSIONS.V_2_79:
+            elif self.blender_version == api_constants.BLENDER_VERSIONS.V_2_79B:
                 layout.prop(self, "blender_279_engine")
 
         elif self.project_type == api_constants.PRODUCTS.VRAY:

--- a/gridmarkets_blender_addon/blender_plugin/remote_project_container/operators/upload_project.py
+++ b/gridmarkets_blender_addon/blender_plugin/remote_project_container/operators/upload_project.py
@@ -158,7 +158,7 @@ class GRIDMARKETS_OT_upload_project(bpy.types.Operator):
             except TypeError:
                 self.report({"WARNING"}, scene.render.engine + " is not supported with this product type")
                 return {"FINISHED"}
-            self.blender_version = api_constants.BLENDER_VERSIONS.V_2_80
+            self.blender_version = utils_blender.map_blender_version_to_api_product_version()
 
         # create popup
         return context.window_manager.invoke_props_dialog(self, width=400)
@@ -224,9 +224,9 @@ class GRIDMARKETS_OT_upload_project(bpy.types.Operator):
             sub1 = layout.row()
             sub1.enabled = False
 
-            if self.blender_version == api_constants.BLENDER_VERSIONS.V_2_80:
+            if self.blender_version == api_constants.BLENDER_VERSIONS.V_2_80 or self.blender_version == api_constants.BLENDER_VERSIONS.V_2_81A:
                 sub1.prop(self, "blender_280_engine")
-            elif self.blender_version == api_constants.BLENDER_VERSIONS.V_2_79:
+            elif self.blender_version == api_constants.BLENDER_VERSIONS.V_2_79B:
                 sub1.prop(self, "blender_279_engine")
 
         elif self.project_type == api_constants.PRODUCTS.VRAY:

--- a/gridmarkets_blender_addon/constants.py
+++ b/gridmarkets_blender_addon/constants.py
@@ -90,9 +90,6 @@ DEFAULT_WINDOW_HIEGHT = 550
 
 BLENDER_TEMP_DIRECTORY = '/tmp\\'
 
-# plugin version
-PLUGIN_VERSION = { "major": 1, "minor": 0, "build" : 1}
-
 PROJECT_PREFIX = 'Project_'
 JOB_PREFIX = 'Job_'
 

--- a/gridmarkets_blender_addon/constants.py
+++ b/gridmarkets_blender_addon/constants.py
@@ -179,7 +179,6 @@ JOB_OPTIONS_BLENDERS_SETTINGS_DESCRIPTION = "Use Blender's render settings when 
 
 # API constants
 JOB_PRODUCT_TYPE = "blender"
-JOB_PRODUCT_VERSION = "2.80"
 JOB_OPERATION = "render"
 
 # add-on tabs

--- a/gridmarkets_blender_addon/operators/open_addon.py
+++ b/gridmarkets_blender_addon/operators/open_addon.py
@@ -52,8 +52,7 @@ class GRIDMARKETS_OT_open_preferences(bpy.types.Operator):
         # save old settings so that they can be restored later
         old_settings = {'x': render.resolution_x,
                         'y': render.resolution_y,
-                        'res_percent': render.resolution_percentage,
-                        'display_mode': render.display_mode}
+                        'res_percent': render.resolution_percentage}
 
         # try finally block so that old settings are guaranteed to be restored
         try:
@@ -67,7 +66,6 @@ class GRIDMARKETS_OT_open_preferences(bpy.types.Operator):
             render.resolution_x = constants.DEFAULT_WINDOW_WIDTH * scale_factor
             render.resolution_y = constants.DEFAULT_WINDOW_HIEGHT * scale_factor
             render.resolution_percentage = 100
-            render.display_mode = "WINDOW"
 
             # Call image editor window. This window just happens to use the render resolution settings for its
             # dimensions.
@@ -102,7 +100,6 @@ class GRIDMARKETS_OT_open_preferences(bpy.types.Operator):
             render.resolution_x = old_settings['x']
             render.resolution_y = old_settings['y']
             render.resolution_percentage = old_settings['res_percent']
-            render.display_mode = old_settings['display_mode']
 
         from gridmarkets_blender_addon.blender_plugin.plugin_fetcher.plugin_fetcher import PluginFetcher
         plugin = PluginFetcher.get_plugin()

--- a/gridmarkets_blender_addon/utils_blender.py
+++ b/gridmarkets_blender_addon/utils_blender.py
@@ -232,7 +232,7 @@ def get_default_blender_job(context, render_file):
     return Job(
         "Default Blender Job",                                      # JOB_NAME
         constants.JOB_PRODUCT_TYPE,                                 # PRODUCT_TYPE
-        constants.JOB_PRODUCT_VERSION,                              # PRODUCT_VERSION
+        map_blender_version_to_api_product_version(),               # PRODUCT_VERSION
         constants.JOB_OPERATION,                                    # OPERATION
         render_file,                                                # RENDER_FILE
         frames = get_blender_frame_range(context),                  # FRAMES
@@ -407,8 +407,9 @@ def get_supported_blender_versions(scene, context):
     from gridmarkets_blender_addon.api_constants import BLENDER_VERSIONS
 
     return [
+        (BLENDER_VERSIONS.V_2_81A, "2.81a", ""),
         (BLENDER_VERSIONS.V_2_80, "2.80", ""),
-        (BLENDER_VERSIONS.V_2_79, "2.79", ""),
+        (BLENDER_VERSIONS.V_2_79B, "2.79b", ""),
     ]
 
 
@@ -428,6 +429,30 @@ def get_supported_blender_280_engines(scene, context):
         (BLENDER_ENGINES.CYCLES, "Cycles", ""),
         (BLENDER_ENGINES.EEVEE, "Eevee", ""),
     ]
+
+
+def map_blender_version_to_api_product_version():
+    from gridmarkets_blender_addon.api_constants import BLENDER_VERSIONS
+    blender_version = bpy.app.version
+
+    major = blender_version[0]
+    minor = blender_version[1]
+    build = blender_version[2]
+
+    # we only support Blender 2.** releases
+    if major != 2:
+        raise Exception("Blender version not supported")
+
+    if minor == 79:
+        return BLENDER_VERSIONS.V_2_79B
+    elif minor == 80:
+        return BLENDER_VERSIONS.V_2_80
+    elif minor == 81:
+        return BLENDER_VERSIONS.V_2_81A
+    elif minor < 90:
+        return BLENDER_VERSIONS.V_2_81A # return the latest blender 2.8* version that we support
+    else:
+        raise Exception("Blender version not supported")
 
 
 def get_supported_vray_versions(scene, context):
@@ -514,7 +539,7 @@ def get_job(context, render_file, enable_logging=True):
         job = Job(
             selected_job.name,
             constants.JOB_PRODUCT_TYPE,
-            constants.JOB_PRODUCT_VERSION,
+            map_blender_version_to_api_product_version(),
             constants.JOB_OPERATION,
             render_file,
             frames=get_job_frame_ranges(context, job=selected_job),


### PR DESCRIPTION
Adds support for Blender 2.81a while retaining Blender 2.80 support.

The feature-dynamic-schema branch has already improved much of this code by handling product versions and different applications much more elegantly. This PR simply extends the old manual way of handling blender product versions to get blender 2.81 supported.

The major blender API change between 2.80 and 2.81 is described below:

In Blender 2.80, there is a `display_mode` attribute on the `bpy.types.RenderSettings` bpy_struct (https://docs.blender.org/api/2.80/bpy.types.RenderSettings.html?highlight=bpy%20types%20rendersettings). But in blender 2.81 that attribute has been renamed to `render_display_type` and moved to the `bpy.types.PreferencesView` bpy_struct (https://docs.blender.org/api/current/bpy.types.PreferencesView.html?highlight=select%20where%20rendered%20images%20displayed) 

